### PR TITLE
 Fixing font color on members page

### DIFF
--- a/css/members.css
+++ b/css/members.css
@@ -68,7 +68,7 @@ h1 {
   bottom: 0;
   padding: 20px;
   background-color: #d2e063;
-  color: black;
+  color: #25384f;
   font-weight: bolder;
   font-size: 1.1em;
 


### PR DESCRIPTION
I've changed the font color on `members` page from `black` to `#25384f` that match the main page.

also kindly could also add `hacktoberfest-accepted` label on this PR?
as I'm aware of this [https://hacktoberfest.digitalocean.com/hacktoberfest-update](url)